### PR TITLE
Fix error on Python3 systems

### DIFF
--- a/.dbuild/relpath.py
+++ b/.dbuild/relpath.py
@@ -1,3 +1,3 @@
 import os.path
 import sys
-print os.path.relpath(sys.argv[1], sys.argv[2])
+print(os.path.relpath(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
On systems with Python3 as standard python version fix the following error

```
  File "/home/nero/repos/bitthunder/.dbuild/../.dbuild/relpath.py", line 3
    print os.path.relpath(sys.argv[1], sys.argv[2])
           ^
SyntaxError: invalid syntax
```
